### PR TITLE
Queue name fix

### DIFF
--- a/src/main/java/com/thirdchannel/rabbitmq/Lago.java
+++ b/src/main/java/com/thirdchannel/rabbitmq/Lago.java
@@ -80,6 +80,7 @@ public class Lago implements com.thirdchannel.rabbitmq.interfaces.Lago {
 
     private void bindConsumer(EventConsumer consumer, int count) {
         consumer.setChannel(createChannel());
+        consumer.setQueueName(consumer.getConfig().getName());
 
         try {
             log.debug("About to make queue with name: " + consumer.getQueueName());

--- a/src/test/groovy/com/thirdchannel/rabbitmq/LagoSetupSpec.groovy
+++ b/src/test/groovy/com/thirdchannel/rabbitmq/LagoSetupSpec.groovy
@@ -35,6 +35,8 @@ class LagoSetupSpec extends Specification {
         !consumer.config.durable
         consumer.config.count == 1
         consumer.config.keys == ["foo.bar"]
+        consumer.config.name == "test1"
+        consumer.getQueueName() == "test1"
         lago.getRegisteredConsumers().size() == 1
     }
 


### PR DESCRIPTION
Sets the queue name instead of defaulting to the class name in order to avoid collisions.